### PR TITLE
update iso url to point to cd-image archive

### DIFF
--- a/ta-debian-7-wheezy-virtualbox-puppet.json
+++ b/ta-debian-7-wheezy-virtualbox-puppet.json
@@ -5,7 +5,7 @@
     "disk_size": 10140,
     "ssh_port": 22,
     "ssh_wait_timeout": "10000s",
-    "iso_url": "http://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-7.8.0-amd64-netinst.iso",
+    "iso_url": "http://cdimage.debian.org/cdimage/archive/7.8.0/amd64/iso-cd/debian-7.8.0-amd64-netinst.iso",
     "iso_md5": "a91fba5001cf0fbccb44a7ae38c63b6e",
     "vm_name": "debian-780-wheezy"
   },

--- a/ta-debian-7-wheezy-virtualbox.json
+++ b/ta-debian-7-wheezy-virtualbox.json
@@ -5,7 +5,7 @@
     "disk_size": 10140,
     "ssh_port": 22,
     "ssh_wait_timeout": "10000s",
-    "iso_url": "http://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-7.8.0-amd64-netinst.iso",
+    "iso_url": "http://cdimage.debian.org/cdimage/archive/7.8.0/amd64/iso-cd/debian-7.8.0-amd64-netinst.iso",
     "iso_md5": "a91fba5001cf0fbccb44a7ae38c63b6e",
     "vm_name": "debian-780-wheezy"
   },

--- a/ta-debian-7-wheezy.json
+++ b/ta-debian-7-wheezy.json
@@ -5,7 +5,7 @@
     "disk_size": 10140,
     "ssh_port": 22,
     "ssh_wait_timeout": "10000s",
-    "iso_url": "http://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-7.8.0-amd64-netinst.iso",
+    "iso_url": "http://cdimage.debian.org/cdimage/archive/7.8.0/amd64/iso-cd/debian-7.8.0-amd64-netinst.iso",
     "iso_md5": "a91fba5001cf0fbccb44a7ae38c63b6e",
     "vm_name": "debian-780-wheezy"
   },


### PR DESCRIPTION
URL of the CD image has moved. Update templates to use the archived version of the iso.
